### PR TITLE
Used uuid as doctrine-identifier

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,21 @@
+UPGRADE
+=======
+
+- [0.4.0](#0.4.0)
+
+### 0.4.0
+
+#### Identifier of tasks and executions
+
+The `id` field has been removed in favour of the `uuid`. This field is of
+type `guid` and can be used before flush.
+
+To upgrade your table-structure follow following steps:
+
+* Copy the output of `bin/console doctrine:schema:update --dump-sql`.
+  Its the direct SQL queries to update your schema.
+* Connect to mysql (with command shell or your favourite client
+* Disable foreign keys checking by running this query: 
+  `set foreign_key_checks=0;`
+* Run the queries from `doctrine:schema:update`
+* Enable back foreign key checking with : `set foreign_key_checks=1;`

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -20,22 +20,9 @@ use Task\Task as BaseTask;
 class Task extends BaseTask
 {
     /**
-     * @var int
-     */
-    private $id;
-
-    /**
      * @var string
      */
     private $intervalExpression;
-
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
 
     /**
      * @return mixed

--- a/src/Entity/TaskExecution.php
+++ b/src/Entity/TaskExecution.php
@@ -18,16 +18,4 @@ use Task\Execution\TaskExecution as BaseTaskExecution;
  */
 class TaskExecution extends BaseTaskExecution
 {
-    /**
-     * @var int
-     */
-    private $id;
-
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
 }

--- a/src/Handler/TaskHandlerFactory.php
+++ b/src/Handler/TaskHandlerFactory.php
@@ -23,14 +23,14 @@ class TaskHandlerFactory implements TaskHandlerFactoryInterface
     /**
      * @var TaskHandlerInterface[]
      */
-    private $handler = [];
+    private $handlers = [];
 
     /**
-     * @param array $handler
+     * @param TaskHandlerInterface[] $handlers
      */
-    public function __construct(array $handler)
+    public function __construct(array $handlers)
     {
-        $this->handler = $handler;
+        $this->handlers = $handlers;
     }
 
     /**
@@ -38,10 +38,20 @@ class TaskHandlerFactory implements TaskHandlerFactoryInterface
      */
     public function create($className)
     {
-        if (!array_key_exists($className, $this->handler)) {
+        if (!array_key_exists($className, $this->handlers)) {
             throw new TaskHandlerNotExistsException($className);
         }
 
-        return $this->handler[$className];
+        return $this->handlers[$className];
+    }
+
+    /**
+     * Returns all known handler.
+     *
+     * @return TaskHandlerInterface[]
+     */
+    public function getHandlers()
+    {
+        return $this->handlers;
     }
 }

--- a/src/Resources/config/doctrine/Task.orm.xml
+++ b/src/Resources/config/doctrine/Task.orm.xml
@@ -9,11 +9,10 @@
             <index columns="uuid"/>
         </indexes>
 
-        <id name="id" type="integer">
-            <generator strategy="AUTO"/>
+        <id name="uuid" type="guid">
+            <generator strategy="NONE"/>
         </id>
 
-        <field name="uuid" type="string" length="100" unique="true"/>
         <field name="handlerClass" type="string" length="255"/>
         <field name="intervalExpression" type="string" length="255" nullable="true"/>
         <field name="firstExecution" type="datetime" nullable="true"/>

--- a/src/Resources/config/doctrine/TaskExecution.orm.xml
+++ b/src/Resources/config/doctrine/TaskExecution.orm.xml
@@ -6,15 +6,13 @@
             repository-class="Task\TaskBundle\Entity\TaskExecutionRepository">
 
         <indexes>
-            <index columns="uuid"/>
             <index columns="schedule_time"/>
         </indexes>
 
-        <id name="id" type="integer">
-            <generator strategy="AUTO"/>
+        <id name="uuid" type="guid">
+            <generator strategy="NONE"/>
         </id>
 
-        <field name="uuid" type="string" length="100" unique="true"/>
         <field name="handlerClass" type="string" length="255"/>
         <field name="workload" type="object"/>
         <field name="duration" type="float" nullable="true"/>
@@ -25,7 +23,9 @@
         <field name="result" type="object" nullable="true"/>
         <field name="status" type="string" length="20"/>
         
-        <many-to-one target-entity="Task\TaskBundle\Entity\Task" field="task"/>
+        <many-to-one target-entity="Task\TaskBundle\Entity\Task" field="task">
+            <join-column name="task_id" referenced-column-name="uuid" on-delete="SET NULL"/>
+        </many-to-one>
 
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
This PR removes the additional id property of task and execution. The uuid can be used earlier because it will be generated during construct.