### PR TITLE
Removed flush of repositories

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -11,6 +11,7 @@
 
 namespace Task\TaskBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,16 +34,27 @@ class RunCommand extends Command
     private $scheduler;
 
     /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
      * @param string $name
      * @param TaskRunnerInterface $runner
      * @param TaskSchedulerInterface $scheduler
+     * @param EntityManagerInterface $entityManager
      */
-    public function __construct($name, TaskRunnerInterface $runner, TaskSchedulerInterface $scheduler)
-    {
+    public function __construct(
+        $name,
+        TaskRunnerInterface $runner,
+        TaskSchedulerInterface $scheduler,
+        EntityManagerInterface $entityManager = null
+    ) {
         parent::__construct($name);
 
         $this->runner = $runner;
         $this->scheduler = $scheduler;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -60,5 +72,9 @@ class RunCommand extends Command
     {
         $this->runner->runTasks();
         $this->scheduler->scheduleTasks();
+
+        if ($this->entityManager) {
+            $this->entityManager->flush();
+        }
     }
 }

--- a/src/Command/ScheduleTaskCommand.php
+++ b/src/Command/ScheduleTaskCommand.php
@@ -11,6 +11,7 @@
 
 namespace Task\TaskBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,14 +30,21 @@ class ScheduleTaskCommand extends Command
     private $scheduler;
 
     /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
      * @param string $name
      * @param TaskSchedulerInterface $runner
+     * @param EntityManagerInterface $entityManager
      */
-    public function __construct($name, TaskSchedulerInterface $runner)
+    public function __construct($name, TaskSchedulerInterface $runner, EntityManagerInterface $entityManager = null)
     {
         parent::__construct($name);
 
         $this->scheduler = $runner;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -84,5 +92,9 @@ class ScheduleTaskCommand extends Command
         }
 
         $taskBuilder->schedule();
+
+        if ($this->entityManager) {
+            $this->entityManager->flush();
+        }
     }
 }

--- a/src/DependencyInjection/TaskExtension.php
+++ b/src/DependencyInjection/TaskExtension.php
@@ -14,6 +14,7 @@ namespace Task\TaskBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -37,6 +38,14 @@ class TaskExtension extends Extension
 
         if ($config['run']['mode'] === 'listener') {
             $loader->load('listener.xml');
+        }
+
+        if ('doctrine' === $config['storage']) {
+            // FIXME move to compiler pass
+            $container->getDefinition('task.command.schedule_task')
+                ->addArgument(new Reference('doctrine.orm.entity_manager'));
+            $container->getDefinition('task.command.run')
+                ->addArgument(new Reference('doctrine.orm.entity_manager'));
         }
     }
 }

--- a/src/Entity/TaskExecutionRepository.php
+++ b/src/Entity/TaskExecutionRepository.php
@@ -34,7 +34,7 @@ class TaskExecutionRepository extends EntityRepository implements TaskExecutionR
     /**
      * {@inheritdoc}
      */
-    public function persist(TaskExecutionInterface $execution)
+    public function save(TaskExecutionInterface $execution)
     {
         $this->_em->persist($execution);
 
@@ -47,16 +47,6 @@ class TaskExecutionRepository extends EntityRepository implements TaskExecutionR
     public function remove(TaskExecutionInterface $execution)
     {
         $this->_em->remove($execution);
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function flush()
-    {
-        $this->_em->flush();
 
         return $this;
     }

--- a/src/Entity/TaskRepository.php
+++ b/src/Entity/TaskRepository.php
@@ -39,7 +39,7 @@ class TaskRepository extends EntityRepository implements TaskRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function persist(TaskInterface $task)
+    public function save(TaskInterface $task)
     {
         $this->_em->persist($task);
 
@@ -52,16 +52,6 @@ class TaskRepository extends EntityRepository implements TaskRepositoryInterface
     public function remove(TaskInterface $task)
     {
         $this->_em->remove($task);
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function flush()
-    {
-        $this->_em->flush();
 
         return $this;
     }

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -7,6 +7,7 @@
             <argument type="string">task:run</argument>
             <argument type="service" id="task.runner"/>
             <argument type="service" id="task.scheduler"/>
+            <!-- add entity_manager if doctrine storage is enabled -->
 
             <tag name="console.command"/>
         </service>
@@ -21,6 +22,7 @@
         <service id="task.command.schedule_task" class="Task\TaskBundle\Command\ScheduleTaskCommand">
             <argument type="string">task:schedule</argument>
             <argument type="service" id="task.scheduler"/>
+            <!-- add entity_manager if doctrine storage is enabled -->
 
             <tag name="console.command"/>
         </service>

--- a/tests/Functional/BaseCommandTestCase.php
+++ b/tests/Functional/BaseCommandTestCase.php
@@ -104,8 +104,7 @@ abstract class BaseCommandTestCase extends KernelTestCase
         if ($cronExpression) {
             $task->setInterval($cronExpression, new \DateTime(), new \DateTime('+1 year'));
         }
-        $this->taskRepository->persist($task);
-        $this->taskRepository->flush();
+        $this->taskRepository->save($task);
 
         return $task;
     }
@@ -123,8 +122,9 @@ abstract class BaseCommandTestCase extends KernelTestCase
     {
         $execution = $this->taskExecutionRepository->create($task, $scheduleTime);
         $execution->setStatus($status);
-        $this->taskExecutionRepository->persist($execution);
-        $this->taskExecutionRepository->flush();
+        $this->taskExecutionRepository->save($execution);
+
+        $this->getEntityManager()->flush();
 
         return $execution;
     }

--- a/tests/Functional/Command/DebugTasksCommandTest.php
+++ b/tests/Functional/Command/DebugTasksCommandTest.php
@@ -35,7 +35,7 @@ class DebugTasksCommandTest extends BaseCommandTestCase
         $executions[1]->setResult(strrev($executions[1]->getWorkload()));
         $executions[1]->setDuration(0.0001);
 
-        $this->taskExecutionRepository->flush();
+        $this->getEntityManager()->flush();
 
         $this->commandTester->execute(
             [
@@ -62,7 +62,7 @@ class DebugTasksCommandTest extends BaseCommandTestCase
             $this->createTaskExecution($task, new \DateTime('+1 hour')),
         ];
 
-        $this->taskExecutionRepository->flush();
+        $this->getEntityManager()->flush();
 
         $this->commandTester->execute(
             [


### PR DESCRIPTION
This PR removes the `flush` method from the repository. Until now the "user" has to be aware that the changes will be persisted.

Related PR: https://github.com/php-task/php-task/pull/22