### PR TITLE
Rename findByStartTime method in repository

### DIFF
--- a/src/Entity/TaskExecutionRepository.php
+++ b/src/Entity/TaskExecutionRepository.php
@@ -73,15 +73,15 @@ class TaskExecutionRepository extends EntityRepository implements TaskExecutionR
     /**
      * {@inheritdoc}
      */
-    public function findByStartTime(TaskInterface $task, \DateTime $scheduleTime)
+    public function findPending(TaskInterface $task)
     {
         try {
             return $this->createQueryBuilder('e')
                 ->innerJoin('e.task', 't')
                 ->where('t.uuid = :uuid')
-                ->andWhere('e.scheduleTime = :scheduleTime')
+                ->andWhere('e.status in (:status)')
                 ->setParameter('uuid', $task->getUuid())
-                ->setParameter('scheduleTime', $scheduleTime)
+                ->setParameter('status', [TaskStatus::PLANNED, TaskStatus::STARTED])
                 ->getQuery()
                 ->getSingleResult();
         } catch (NoResultException $e) {

--- a/tests/Functional/Command/DebugTasksCommandTest.php
+++ b/tests/Functional/Command/DebugTasksCommandTest.php
@@ -26,8 +26,8 @@ class DebugTasksCommandTest extends BaseCommandTestCase
 
         /** @var TaskExecutionInterface[] $executions */
         $executions = [
-            $this->createTaskExecution($task, new \DateTime('-1 hour'), TaskStatus::COMPLETE),
-            $this->createTaskExecution($task, new \DateTime('-2 hour'), TaskStatus::COMPLETE),
+            $this->createTaskExecution($task, new \DateTime('-1 hour'), TaskStatus::COMPLETED),
+            $this->createTaskExecution($task, new \DateTime('-2 hour'), TaskStatus::COMPLETED),
         ];
 
         $executions[0]->setResult(strrev($executions[0]->getWorkload()));

--- a/tests/Functional/Command/RunCommandTest.php
+++ b/tests/Functional/Command/RunCommandTest.php
@@ -42,7 +42,7 @@ class RunCommandTest extends BaseCommandTestCase
             ]
         );
 
-        $this->assertEquals(TaskStatus::COMPLETE, $executions[0]->getStatus());
+        $this->assertEquals(TaskStatus::COMPLETED, $executions[0]->getStatus());
         $this->assertEquals(strrev('Test workload 1'), $executions[0]->getResult());
         $this->assertGreaterThan(0, $executions[0]->getDuration());
         $this->assertGreaterThanOrEqual($executions[0]->getStartTime(), $executions[0]->getEndTime());
@@ -53,7 +53,7 @@ class RunCommandTest extends BaseCommandTestCase
         $this->assertNull($executions[1]->getStartTime());
         $this->assertNull($executions[1]->getEndTime());
 
-        $this->assertEquals(TaskStatus::COMPLETE, $executions[2]->getStatus());
+        $this->assertEquals(TaskStatus::COMPLETED, $executions[2]->getStatus());
         $this->assertEquals(strrev('Test workload 3'), $executions[2]->getResult());
         $this->assertGreaterThan(0, $executions[2]->getDuration());
         $this->assertGreaterThanOrEqual($executions[2]->getStartTime(), $executions[2]->getEndTime());


### PR DESCRIPTION
After refactoring schedule tasks in the library (https://github.com/php-task/php-task/pull/24) the method `findByStartTime` was renamed to `findPending`.