### PR TITLE
Fixed query to find pending executions

### DIFF
--- a/src/Entity/TaskExecutionRepository.php
+++ b/src/Entity/TaskExecutionRepository.php
@@ -129,18 +129,15 @@ class TaskExecutionRepository extends EntityRepository implements TaskExecutionR
     /**
      * {@inheritdoc}
      */
-    public function findScheduled(\DateTime $dateTime = null)
+    public function findScheduled()
     {
-        if ($dateTime === null) {
-            $dateTime = new \DateTime();
-        }
-
-        return $this->createQueryBuilder('e')
+        $query = $this->createQueryBuilder('e')
             ->innerJoin('e.task', 't')
-            ->where('e.status = :status AND e.scheduleTime < :dateTime')
+            ->where('e.status = :status')
+            ->andWhere('e.scheduleTime < CURRENT_TIMESTAMP()')
             ->setParameter('status', TaskStatus::PLANNED)
-            ->setParameter('dateTime', $dateTime)
-            ->getQuery()
-            ->getResult();
+            ->getQuery();
+
+        return $query->getResult();
     }
 }

--- a/tests/Functional/BaseDatabaseTestCase.php
+++ b/tests/Functional/BaseDatabaseTestCase.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Task\TaskBundle\Tests\Functional;
+
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Extends kernel-test-case with additional functions/properties.
+ */
+abstract class BaseDatabaseTestCase extends KernelTestCase
+{
+    const ENTITY_MANAGER_ID = 'doctrine.orm.entity_manager';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        self::bootKernel();
+
+        $this->purgeDatabase();
+    }
+
+    /**
+     * Purges database is necessary.
+     */
+    protected function purgeDatabase()
+    {
+        if (!self::$kernel->getContainer()->has(self::ENTITY_MANAGER_ID)) {
+            return;
+        }
+
+        /** @var EntityManagerInterface $manager */
+        $manager = self::$kernel->getContainer()->get(self::ENTITY_MANAGER_ID);
+        $connection = $manager->getConnection();
+
+        if ($connection->getDriver() instanceof \Doctrine\DBAL\Driver\PDOMySql\Driver) {
+            $connection->executeUpdate('SET foreign_key_checks = 0;');
+        }
+
+        $purger = new ORMPurger();
+        $executor = new ORMExecutor($manager, $purger);
+        $referenceRepository = new ProxyReferenceRepository($manager);
+        $executor->setReferenceRepository($referenceRepository);
+        $executor->purge();
+
+        if ($connection->getDriver() instanceof \Doctrine\DBAL\Driver\PDOMySql\Driver) {
+            $connection->executeUpdate('SET foreign_key_checks = 1;');
+        }
+    }
+}

--- a/tests/Functional/Entity/TaskExecutionRepositoryTest.php
+++ b/tests/Functional/Entity/TaskExecutionRepositoryTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Task\TaskBundle\Tests\Functional\Command;
+
+use Task\Execution\TaskExecutionInterface;
+use Task\Storage\TaskExecutionRepositoryInterface;
+use Task\Storage\TaskRepositoryInterface;
+use Task\TaskBundle\Entity\Task;
+use Task\TaskBundle\Entity\TaskExecution;
+use Task\TaskBundle\Tests\Functional\BaseDatabaseTestCase;
+use Task\TaskBundle\Tests\Functional\TestHandler;
+use Task\TaskInterface;
+use Task\TaskStatus;
+
+/**
+ * Tests for TaskExecutionRepository.
+ */
+class TaskExecutionRepositoryTest extends BaseDatabaseTestCase
+{
+    /**
+     * @var TaskExecutionRepositoryInterface
+     */
+    protected $taskExecutionRepository;
+
+    /**
+     * @var TaskRepositoryInterface
+     */
+    protected $taskRepository;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->taskExecutionRepository = self::$kernel->getContainer()->get('task.storage.task_execution');
+        $this->taskRepository = self::$kernel->getContainer()->get('task.storage.task');
+    }
+
+    public function testSave()
+    {
+        $execution = $this->save();
+
+        $result = $this->taskExecutionRepository->findByUuid($execution->getUuid());
+
+        $this->assertEquals($execution->getUuid(), $result->getUuid());
+        $this->assertEquals($execution->getScheduleTime(), $result->getScheduleTime());
+        $this->assertEquals($execution->getStatus(), $result->getStatus());
+        $this->assertEquals($execution->getTask()->getUuid(), $result->getTask()->getUuid());
+    }
+
+    public function testRemove()
+    {
+        $execution = $this->save();
+
+        $this->taskExecutionRepository->remove($execution);
+
+        $this->assertNull($this->taskExecutionRepository->findByUuid($execution->getUuid()));
+    }
+
+    public function testFindAll()
+    {
+        $task = $this->createTask();
+        $this->taskRepository->save($task);
+
+        $executions = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $execution = $this->save($task);
+            $executions[$execution->getUuid()] = $execution;
+        }
+
+        $result = $this->taskExecutionRepository->findAll();
+
+        $this->assertCount(3, $result);
+        foreach ($result as $item) {
+            $this->assertArrayHasKey($item->getUuid(), $executions);
+            unset($executions[$item->getUuid()]);
+        }
+    }
+
+    public function testFindAllPaginated()
+    {
+        $task = $this->createTask();
+        $this->taskRepository->save($task);
+
+        $executions = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $execution = $this->save($task);
+            $executions[$execution->getUuid()] = $execution;
+        }
+
+        $result = $this->taskExecutionRepository->findAll(1, 2);
+
+        $this->assertCount(2, $result);
+        foreach ($result as $item) {
+            $this->assertArrayHasKey($item->getUuid(), $executions);
+            unset($executions[$item->getUuid()]);
+        }
+
+        $result = $this->taskExecutionRepository->findAll(2, 2);
+
+        $this->assertCount(1, $result);
+        foreach ($result as $item) {
+            $this->assertArrayHasKey($item->getUuid(), $executions);
+            unset($executions[$item->getUuid()]);
+        }
+
+        $this->assertEmpty($executions);
+    }
+
+    public function testFindPending()
+    {
+        $execution = $this->save();
+        $this->assertNotNull($this->taskExecutionRepository->findPending($execution->getTask()));
+
+        $execution = $this->save(null, null, TaskStatus::RUNNING);
+        $this->assertNotNull($this->taskExecutionRepository->findPending($execution->getTask()));
+
+        $execution = $this->save(null, null, TaskStatus::COMPLETED);
+        $this->assertNull($this->taskExecutionRepository->findPending($execution->getTask()));
+
+        $execution = $this->save(null, null, TaskStatus::FAILED);
+        $this->assertNull($this->taskExecutionRepository->findPending($execution->getTask()));
+    }
+
+    public function testFindByUuid()
+    {
+        $execution = $this->save();
+
+        $result = $this->taskExecutionRepository->findByUuid($execution->getUuid());
+        $this->assertEquals($execution->getUuid(), $result->getUuid());
+    }
+
+    public function testFindByTask()
+    {
+        $execution = $this->save();
+
+        $result = $this->taskExecutionRepository->findByTask($execution->getTask());
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($execution->getTask()->getUuid(), $result[0]->getTask()->getUuid());
+    }
+
+    public function testFindByTaskUuid()
+    {
+        $execution = $this->save();
+
+        $result = $this->taskExecutionRepository->findByTaskUuid($execution->getTask()->getUuid());
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($execution->getTask()->getUuid(), $result[0]->getTask()->getUuid());
+    }
+
+    public function testFindScheduledPast()
+    {
+        $task = $this->createTask();
+        $this->taskRepository->save($task);
+
+        $execution = $this->save($task, new \DateTime('-1 hour'));
+
+        $result = $this->taskExecutionRepository->findScheduled();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($execution->getUuid(), $result[0]->getUuid());
+    }
+
+    public function testFindScheduledFuture()
+    {
+        $task = $this->createTask();
+        $this->taskRepository->save($task);
+
+        $this->save($task, new \DateTime('+1 hour'));
+
+        $this->assertEmpty($this->taskExecutionRepository->findScheduled());
+    }
+
+    /**
+     * Save a new execution to database.
+     *
+     * @param TaskInterface $task
+     * @param \DateTime $scheduleTime
+     * @param string $status
+     *
+     * @return TaskExecutionInterface
+     */
+    private function save(TaskInterface $task = null, \DateTime $scheduleTime = null, $status = TaskStatus::PLANNED)
+    {
+        if (!$scheduleTime) {
+            $scheduleTime = new \DateTime();
+        }
+
+        if (!$task) {
+            $task = $this->createTask();
+            $this->taskRepository->save($task);
+        }
+
+        $execution = $this->createTaskExecution($task, $scheduleTime, $status);
+        $this->taskExecutionRepository->save($execution);
+
+        return $execution;
+    }
+
+    /**
+     * Create a new task.
+     *
+     * @param string $handlerClass
+     *
+     * @return TaskInterface
+     */
+    private function createTask($handlerClass = TestHandler::class)
+    {
+        return new Task($handlerClass);
+    }
+
+    /**
+     * Create a new task-execution.
+     *
+     * @param TaskInterface $task
+     * @param \DateTime $scheduleTime
+     * @param string $status
+     *
+     * @return TaskExecutionInterface
+     */
+    private function createTaskExecution(TaskInterface $task, \DateTime $scheduleTime, $status = TaskStatus::PLANNED)
+    {
+        $execution = new TaskExecution($task, $task->getHandlerClass(), $scheduleTime);
+        $execution->setStatus($status);
+
+        return $execution;
+    }
+}


### PR DESCRIPTION
This PR fixes the query for `findPending` and make it independent from timezone (by using `now` and give the decision to the database).