### PR TITLE
Implemented system-tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - STORAGE=doctrine tests/app/console doctrine:schema:create
 
 script:
-   - phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
+   - vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
 
 after_script:
   - if [[ $CODE_COVERAGE == 'true' ]]; then wget https://scrutinizer-ci.com/ocular.phar ; fi

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,7 +1,17 @@
 UPGRADE
 =======
 
+- [1.1.0](#1.1.0)
 - [0.4.0](#0.4.0)
+
+### 1.1.0
+
+In the database table `ta_tasks` a new field was introduced. Run following
+command to update the table.
+
+```bash
+bin/console doctrine:schema:update
+```
 
 ### 0.4.0
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "~5.5 || ~7.0",
-        "php-task/php-task": "dev-feature/aborted-execution",
+        "php-task/php-task": "dev-develop",
         "symfony/http-kernel": "^2.6 || ^3.0",
         "symfony/dependency-injection": "^2.6 || ^3.0",
         "symfony/config": "^2.6 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "~5.5 || ~7.0",
-        "php-task/php-task": "^1.0",
+        "php-task/php-task": "dev-feature/aborted-execution",
         "symfony/http-kernel": "^2.6 || ^3.0",
         "symfony/dependency-injection": "^2.6 || ^3.0",
         "symfony/config": "^2.6 || ^3.0",

--- a/src/Builder/NotSupportedMethodException.php
+++ b/src/Builder/NotSupportedMethodException.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of php-task library.
+ *
+ * (c) php-task
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Task\TaskBundle\Builder;
+
+use Task\TaskInterface;
+
+/**
+ * Indicates not supported method.
+ */
+class NotSupportedMethodException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $property;
+
+    /**
+     * @var TaskInterface
+     */
+    private $task;
+
+    /**
+     * @param string $property
+     * @param TaskInterface $task
+     */
+    public function __construct($property, TaskInterface $task)
+    {
+        parent::__construct(
+            sprintf('Property "%s" is not supported for task-class "%s".', $property, get_class($task))
+        );
+
+        $this->property = $property;
+        $this->task = $task;
+    }
+
+    /**
+     * Returns property.
+     *
+     * @return string
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    /**
+     * Returns task.
+     *
+     * @return TaskInterface
+     */
+    public function getTask()
+    {
+        return $this->task;
+    }
+}

--- a/src/Builder/TaskBuilder.php
+++ b/src/Builder/TaskBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of php-task library.
+ *
+ * (c) php-task
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Task\TaskBundle\Builder;
+
+use Task\Builder\TaskBuilder as BaseTaskBuilder;
+use Task\Builder\TaskBuilderInterface;
+use Task\Scheduler\TaskSchedulerInterface;
+use Task\TaskBundle\Entity\Task;
+use Task\TaskInterface;
+
+/**
+ * Extends base task-builder.
+ */
+class TaskBuilder extends BaseTaskBuilder
+{
+    /**
+     * @var TaskInterface
+     */
+    private $task;
+
+    /**
+     * @param TaskInterface $task
+     * @param TaskSchedulerInterface $taskScheduler
+     */
+    public function __construct(TaskInterface $task, TaskSchedulerInterface $taskScheduler)
+    {
+        parent::__construct($task, $taskScheduler);
+
+        $this->task = $task;
+    }
+
+    /**
+     * Set system-key.
+     *
+     * @param string $systemKey
+     *
+     * @return TaskBuilderInterface
+     *
+     * @throws NotSupportedMethodException
+     */
+    public function setSystemKey($systemKey)
+    {
+        if (!$this->task instanceof Task) {
+            throw new NotSupportedMethodException('systemKey', $this->task);
+        }
+
+        $this->task->setSystemKey($systemKey);
+
+        return $this;
+    }
+}

--- a/src/Builder/TaskBuilder.php
+++ b/src/Builder/TaskBuilder.php
@@ -13,31 +13,13 @@ namespace Task\TaskBundle\Builder;
 
 use Task\Builder\TaskBuilder as BaseTaskBuilder;
 use Task\Builder\TaskBuilderInterface;
-use Task\Scheduler\TaskSchedulerInterface;
 use Task\TaskBundle\Entity\Task;
-use Task\TaskInterface;
 
 /**
  * Extends base task-builder.
  */
 class TaskBuilder extends BaseTaskBuilder
 {
-    /**
-     * @var TaskInterface
-     */
-    private $task;
-
-    /**
-     * @param TaskInterface $task
-     * @param TaskSchedulerInterface $taskScheduler
-     */
-    public function __construct(TaskInterface $task, TaskSchedulerInterface $taskScheduler)
-    {
-        parent::__construct($task, $taskScheduler);
-
-        $this->task = $task;
-    }
-
     /**
      * Set system-key.
      *

--- a/src/Builder/TaskBuilderFactory.php
+++ b/src/Builder/TaskBuilderFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of php-task library.
+ *
+ * (c) php-task
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Task\TaskBundle\Builder;
+
+use Task\Builder\TaskBuilderFactoryInterface;
+use Task\Scheduler\TaskSchedulerInterface;
+use Task\TaskInterface;
+
+/**
+ * Factory to create new task-builders.
+ */
+class TaskBuilderFactory implements TaskBuilderFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createTaskBuilder(TaskInterface $task, TaskSchedulerInterface $taskScheduler)
+    {
+        return new TaskBuilder($task, $taskScheduler);
+    }
+}

--- a/src/Command/ScheduleSystemTasksCommand.php
+++ b/src/Command/ScheduleSystemTasksCommand.php
@@ -98,6 +98,12 @@ EOT
             }
         }
 
+        foreach ($this->taskRepository->findSystemTasks() as $task) {
+            if (!in_array($task->getSystemKey(), array_keys($this->systemTasks))) {
+                $this->disableTask($task);
+            }
+        }
+
         $output->writeln('');
         $output->writeln('System-tasks successfully scheduled');
     }
@@ -112,7 +118,7 @@ EOT
     private function processSystemTask($systemKey, array $systemTask, OutputInterface $output)
     {
         if (!$systemTask['enabled']) {
-            $this->disableTask($systemKey);
+            $this->disableSystemTask($systemKey);
 
             $output->writeln(sprintf(' * System-task "%s" was <info>disabled</info>.', $systemKey));
 
@@ -144,12 +150,22 @@ EOT
      *
      * @param string $systemKey
      */
-    private function disableTask($systemKey)
+    private function disableSystemTask($systemKey)
     {
         if (!$task = $this->taskRepository->findBySystemKey($systemKey)) {
             return;
         }
 
+        $this->disableTask($task);
+    }
+
+    /**
+     * Disable given task identified.
+     *
+     * @param TaskInterface $task
+     */
+    public function disableTask(TaskInterface $task)
+    {
         $task->setInterval($task->getInterval(), $task->getFirstExecution(), new \DateTime());
         $this->abortPending($task);
     }

--- a/src/Command/ScheduleSystemTasksCommand.php
+++ b/src/Command/ScheduleSystemTasksCommand.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Task\TaskBundle\Command;
+
+use Cron\CronExpression;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Task\Scheduler\TaskSchedulerInterface;
+use Task\Storage\TaskExecutionRepositoryInterface;
+use Task\TaskBundle\Builder\TaskBuilder;
+use Task\TaskBundle\Entity\TaskRepository;
+use Task\TaskInterface;
+
+/**
+ * Schedules configured system-tasks.
+ */
+class ScheduleSystemTasksCommand extends Command
+{
+    /**
+     * @var array
+     */
+    private $systemTasks;
+
+    /**
+     * @var TaskSchedulerInterface
+     */
+    private $scheduler;
+
+    /**
+     * @var TaskRepository
+     */
+    private $taskRepository;
+
+    /**
+     * @var TaskExecutionRepositoryInterface
+     */
+    private $taskExecutionRepository;
+
+    /**
+     * @param string $name
+     * @param array $systemTasks
+     * @param TaskSchedulerInterface $scheduler
+     * @param TaskRepository $taskRepository
+     * @param TaskExecutionRepositoryInterface $taskExecutionRepository
+     */
+    public function __construct(
+        $name,
+        array $systemTasks,
+        TaskSchedulerInterface $scheduler,
+        TaskRepository $taskRepository,
+        TaskExecutionRepositoryInterface $taskExecutionRepository
+    ) {
+        parent::__construct($name);
+
+        $this->systemTasks = $systemTasks;
+        $this->scheduler = $scheduler;
+        $this->taskRepository = $taskRepository;
+        $this->taskExecutionRepository = $taskExecutionRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setDescription('Schedule system-tasks')->setHelp(
+            <<<'EOT'
+The <info>%command.name%</info> command schedules configured system tasks.
+
+    $ %command.full_name%
+
+You can configure them by extending the <info>task.system_task</info> array in your config file.
+EOT
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(sprintf('Schedule %s system-tasks:', count($this->systemTasks)));
+        $output->writeln('');
+
+        foreach ($this->systemTasks as $systemKey => $systemTask) {
+            try {
+                $this->processSystemTask($systemKey, $systemTask, $output);
+            } catch (\Exception $exception) {
+                $output->writeln(
+                    sprintf(
+                        ' * System-task "%s" failed because of: <exception>%s</exception>',
+                        $systemKey,
+                        $exception->getMessage()
+                    )
+                );
+            }
+        }
+
+
+        $output->writeln('');
+        $output->writeln('System-tasks successfully scheduled');
+    }
+
+    /**
+     * Process single system task.
+     *
+     * @param string $systemKey
+     * @param array $systemTask
+     * @param OutputInterface $output
+     */
+    private function processSystemTask($systemKey, array $systemTask, OutputInterface $output)
+    {
+        if (!$systemTask['enabled']) {
+            $this->disableTask($systemKey);
+
+            $output->writeln(sprintf(' * System-task "%s" was <info>disabled</info>.', $systemKey));
+
+            return;
+        }
+
+        if ($task = $this->taskRepository->findBySystemKey($systemKey)) {
+            $this->updateTask($systemKey, $systemTask, $task);
+
+            $output->writeln(sprintf(' * System-task "%s" was <info>updated</info>.', $systemKey));
+
+            return;
+        }
+
+        /** @var TaskBuilder $builder */
+        $builder = $this->scheduler->createTask($systemTask['handler_class'], $systemTask['workload']);
+        $builder->setSystemKey($systemKey);
+        if ($systemTask['cron_expression']) {
+            $builder->cron($systemTask['cron_expression']);
+        }
+
+        $builder->schedule();
+
+        $output->writeln(sprintf(' * System-task "%s" was <info>created</info>.', $systemKey));
+    }
+
+    /**
+     * Disable task identified by system-key.
+     *
+     * @param string $systemKey
+     */
+    private function disableTask($systemKey)
+    {
+        if (!$task = $this->taskRepository->findBySystemKey($systemKey)) {
+            return;
+        }
+
+        $task->setInterval($task->getInterval(), $task->getFirstExecution(), new \DateTime());
+        $this->removePending($task);
+    }
+
+    /**
+     * Update given task.
+     *
+     * @param string $systemKey
+     * @param array $systemTask
+     * @param TaskInterface $task
+     */
+    private function updateTask($systemKey, array $systemTask, TaskInterface $task)
+    {
+        if ($task->getHandlerClass() !== $systemTask['handler_class']
+            || $task->getWorkload() !== $systemTask['workload']
+        ) {
+            throw new \InvalidArgumentException(
+                sprintf('No update of handle-class or workload is supported for system-task "%s".', $systemKey)
+            );
+        }
+
+        if ($task->getInterval() === $systemTask['cron_expression']) {
+            return;
+        }
+
+        $task->setInterval(CronExpression::factory($systemTask['cron_expression']), $task->getFirstExecution());
+
+        $this->removePending($task);
+        $this->scheduler->scheduleTasks();
+    }
+
+    /**
+     * Remove pending execution for given task.
+     *
+     * @param TaskInterface $task
+     */
+    private function removePending(TaskInterface $task)
+    {
+        if (!$execution = $this->taskExecutionRepository->findPending($task)) {
+            return;
+        }
+
+        $this->taskExecutionRepository->remove($execution);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -49,6 +49,16 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('system_tasks')
+                    ->prototype('array')
+                        ->children()
+                            ->booleanNode('enabled')->defaultTrue()->end()
+                            ->scalarNode('handler_class')->end()
+                            ->variableNode('workload')->defaultNull()->end()
+                            ->scalarNode('cron_expression')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/TaskExtension.php
+++ b/src/DependencyInjection/TaskExtension.php
@@ -34,6 +34,9 @@ class TaskExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        $container->setParameter('task.system_tasks', $config['system_tasks']);
+        $container->setParameter('task.storage', $config['storage']);
+
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load(sprintf('storage/%s.xml', $config['storage']));
         $loader->load('task_event_listener.xml');

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -25,6 +25,11 @@ class Task extends BaseTask
     private $intervalExpression;
 
     /**
+     * @var string
+     */
+    private $systemKey;
+
+    /**
      * @return mixed
      */
     public function getIntervalExpression()
@@ -32,6 +37,9 @@ class Task extends BaseTask
         return $this->intervalExpression;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getInterval()
     {
         if (null === $this->interval && null !== $this->intervalExpression) {
@@ -49,5 +57,29 @@ class Task extends BaseTask
         parent::setInterval($interval, $firstExecution, $lastExecution);
 
         $this->intervalExpression = $interval->getExpression();
+    }
+
+    /**
+     * Returns system-key.
+     *
+     * @return string
+     */
+    public function getSystemKey()
+    {
+        return $this->systemKey;
+    }
+
+    /**
+     * Set system-key.
+     *
+     * @param string $systemKey
+     *
+     * @return $this
+     */
+    public function setSystemKey($systemKey)
+    {
+        $this->systemKey = $systemKey;
+
+        return $this;
     }
 }

--- a/src/Entity/TaskRepository.php
+++ b/src/Entity/TaskRepository.php
@@ -118,4 +118,17 @@ class TaskRepository extends EntityRepository implements TaskRepositoryInterface
             return;
         }
     }
+
+    /**
+     * Returns all system-task.
+     *
+     * @return TaskInterface[]
+     */
+    public function findSystemTasks()
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.systemKey IS NOT NULL')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Entity/TaskRepository.php
+++ b/src/Entity/TaskRepository.php
@@ -12,6 +12,7 @@
 namespace Task\TaskBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NoResultException;
 use Task\Storage\TaskRepositoryInterface;
 use Task\TaskInterface;
 
@@ -96,5 +97,25 @@ class TaskRepository extends EntityRepository implements TaskRepositoryInterface
             ->setParameter('dateTime', $dateTime)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * Returns task identified by system-key.
+     *
+     * @param string $systemKey
+     *
+     * @return TaskInterface
+     */
+    public function findBySystemKey($systemKey)
+    {
+        try {
+            return $this->createQueryBuilder('t')
+                ->where('t.systemKey = :systemKey')
+                ->setParameter('systemKey', $systemKey)
+                ->getQuery()
+                ->getSingleResult();
+        } catch (NoResultException $exception) {
+            return;
+        }
     }
 }

--- a/src/Resources/config/doctrine/Task.orm.xml
+++ b/src/Resources/config/doctrine/Task.orm.xml
@@ -17,6 +17,7 @@
         <field name="intervalExpression" type="string" length="255" nullable="true"/>
         <field name="firstExecution" type="datetime" nullable="true"/>
         <field name="lastExecution" type="datetime" nullable="true"/>
+        <field name="systemKey" type="string" nullable="true" unique="true"/>
         <field name="workload" type="object"/>
 
     </entity>

--- a/src/Resources/config/scheduler.xml
+++ b/src/Resources/config/scheduler.xml
@@ -3,7 +3,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="task.builder_factory" class="Task\Builder\TaskBuilderFactory"/>
+        <service id="task.builder_factory" class="Task\TaskBundle\Builder\TaskBuilderFactory"/>
 
         <service id="task.scheduler" class="Task\Scheduler\TaskScheduler">
             <argument type="service" id="task.builder_factory"/>

--- a/src/Resources/config/storage/doctrine.xml
+++ b/src/Resources/config/storage/doctrine.xml
@@ -16,5 +16,15 @@
             <argument type="string">TaskBundle:TaskExecution</argument>
         </service>
         <service id="task.storage.task_execution" alias="task.repository.task_execution"/>
+
+        <service id="task.command.schedule_system_tasks" class="Task\TaskBundle\Command\ScheduleSystemTasksCommand">
+            <argument type="string">task:schedule:system-tasks</argument>
+            <argument>%task.system_tasks%</argument>
+            <argument type="service" id="task.scheduler"/>
+            <argument type="service" id="task.repository.task"/>
+            <argument type="service" id="task.storage.task_execution"/>
+
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/tests/Functional/BaseDatabaseTestCase.php
+++ b/tests/Functional/BaseDatabaseTestCase.php
@@ -7,6 +7,10 @@ use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Task\TaskBundle\Entity\Task;
+use Task\TaskBundle\Entity\TaskExecution;
+use Task\TaskInterface;
+use Task\TaskStatus;
 
 /**
  * Extends kernel-test-case with additional functions/properties.
@@ -51,5 +55,34 @@ abstract class BaseDatabaseTestCase extends KernelTestCase
         if ($connection->getDriver() instanceof \Doctrine\DBAL\Driver\PDOMySql\Driver) {
             $connection->executeUpdate('SET foreign_key_checks = 1;');
         }
+    }
+
+    /**
+     * Create a new task.
+     *
+     * @param string $handlerClass
+     *
+     * @return Task
+     */
+    protected function createTask($handlerClass = TestHandler::class)
+    {
+        return new Task($handlerClass);
+    }
+
+    /**
+     * Create a new task-execution.
+     *
+     * @param TaskInterface $task
+     * @param \DateTime $scheduleTime
+     * @param string $status
+     *
+     * @return TaskExecution
+     */
+    protected function createTaskExecution(TaskInterface $task, \DateTime $scheduleTime, $status = TaskStatus::PLANNED)
+    {
+        $execution = new TaskExecution($task, $task->getHandlerClass(), $scheduleTime);
+        $execution->setStatus($status);
+
+        return $execution;
     }
 }

--- a/tests/Functional/Command/RunHandlerCommandTest.php
+++ b/tests/Functional/Command/RunHandlerCommandTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Functional\Command;
+namespace Task\TaskBundle\Functional\Command;
 
 use Symfony\Component\Console\Output\OutputInterface;
 use Task\TaskBundle\Tests\Functional\BaseCommandTestCase;

--- a/tests/Functional/Command/ScheduleSystemTasksCommandTest.php
+++ b/tests/Functional/Command/ScheduleSystemTasksCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Task\TaskBundle\Functional\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Task\TaskBundle\Tests\Functional\BaseCommandTestCase;
+
+class ScheduleSystemTasksCommandTest extends BaseCommandTestCase
+{
+    public function testExecute()
+    {
+        if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
+            return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
+        }
+
+        $this->commandTester->execute(
+            [
+                'command' => $this->command->getName(),
+            ]
+        );
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertContains('System-tasks successfully scheduled', $output);
+
+        $taskRepository = self::$kernel->getContainer()->get('task.repository.task');
+        $this->assertNotNull($taskRepository->findBySystemKey('testing'));
+
+    }
+
+    /**
+     * Returns command.
+     *
+     * @return Command
+     */
+    protected function getCommand()
+    {
+        return self::$kernel->getContainer()->get('task.command.schedule_system_tasks');
+    }
+}

--- a/tests/Functional/Command/ScheduleSystemTasksCommandTest.php
+++ b/tests/Functional/Command/ScheduleSystemTasksCommandTest.php
@@ -7,12 +7,16 @@ use Task\TaskBundle\Tests\Functional\BaseCommandTestCase;
 
 class ScheduleSystemTasksCommandTest extends BaseCommandTestCase
 {
-    public function testExecute()
+    public function setUp()
     {
+        self::bootKernel();
         if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
             return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
         }
+    }
 
+    public function testExecute()
+    {
         $this->commandTester->execute(
             [
                 'command' => $this->command->getName(),
@@ -24,7 +28,6 @@ class ScheduleSystemTasksCommandTest extends BaseCommandTestCase
 
         $taskRepository = self::$kernel->getContainer()->get('task.repository.task');
         $this->assertNotNull($taskRepository->findBySystemKey('testing'));
-
     }
 
     /**

--- a/tests/Functional/Command/ScheduleSystemTasksCommandTest.php
+++ b/tests/Functional/Command/ScheduleSystemTasksCommandTest.php
@@ -13,6 +13,8 @@ class ScheduleSystemTasksCommandTest extends BaseCommandTestCase
         if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
             return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
         }
+
+        parent::setUp();
     }
 
     public function testExecute()

--- a/tests/Functional/Command/ScheduleTaskCommandTest.php
+++ b/tests/Functional/Command/ScheduleTaskCommandTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Functional\Command;
+namespace Task\TaskBundle\Functional\Command;
 
 use Task\TaskBundle\Tests\Functional\BaseCommandTestCase;
 use Task\TaskBundle\Tests\Functional\TestHandler;

--- a/tests/Functional/Entity/TaskExecutionRepositoryTest.php
+++ b/tests/Functional/Entity/TaskExecutionRepositoryTest.php
@@ -6,9 +6,7 @@ use Task\Execution\TaskExecutionInterface;
 use Task\Storage\TaskExecutionRepositoryInterface;
 use Task\Storage\TaskRepositoryInterface;
 use Task\TaskBundle\Entity\Task;
-use Task\TaskBundle\Entity\TaskExecution;
 use Task\TaskBundle\Tests\Functional\BaseDatabaseTestCase;
-use Task\TaskBundle\Tests\Functional\TestHandler;
 use Task\TaskInterface;
 use Task\TaskStatus;
 

--- a/tests/Functional/Entity/TaskExecutionRepositoryTest.php
+++ b/tests/Functional/Entity/TaskExecutionRepositoryTest.php
@@ -197,33 +197,4 @@ class TaskExecutionRepositoryTest extends BaseDatabaseTestCase
 
         return $execution;
     }
-
-    /**
-     * Create a new task.
-     *
-     * @param string $handlerClass
-     *
-     * @return TaskInterface
-     */
-    private function createTask($handlerClass = TestHandler::class)
-    {
-        return new Task($handlerClass);
-    }
-
-    /**
-     * Create a new task-execution.
-     *
-     * @param TaskInterface $task
-     * @param \DateTime $scheduleTime
-     * @param string $status
-     *
-     * @return TaskExecutionInterface
-     */
-    private function createTaskExecution(TaskInterface $task, \DateTime $scheduleTime, $status = TaskStatus::PLANNED)
-    {
-        $execution = new TaskExecution($task, $task->getHandlerClass(), $scheduleTime);
-        $execution->setStatus($status);
-
-        return $execution;
-    }
 }

--- a/tests/Functional/Entity/TaskRepositoryTest.php
+++ b/tests/Functional/Entity/TaskRepositoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Task\TaskBundle\Tests\Functional\Entity;
+
+use Task\TaskBundle\Entity\TaskRepository;
+use Task\TaskBundle\Tests\Functional\BaseDatabaseTestCase;
+
+class TaskRepositoryTest extends BaseDatabaseTestCase
+{
+    /**
+     * @var TaskRepository
+     */
+    protected $taskRepository;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->taskRepository = self::$kernel->getContainer()->get('task.storage.task');
+    }
+
+    public function testFinBySystemKey()
+    {
+        if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
+            return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
+        }
+
+        $task = $this->createTask();
+        $task->setSystemKey('test');
+
+        $this->taskRepository->save($task);
+
+        $result = $this->taskRepository->findBySystemKey('test');
+        $this->assertEquals($task->getUuid(), $result->getUuid());
+    }
+
+    public function testFinBySystemKeyNotFound()
+    {
+        if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
+            return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
+        }
+
+        $task = $this->createTask();
+        $this->taskRepository->save($task);
+
+        $this->assertNull($this->taskRepository->findBySystemKey('test'));
+    }
+}

--- a/tests/Functional/Entity/TaskRepositoryTest.php
+++ b/tests/Functional/Entity/TaskRepositoryTest.php
@@ -19,7 +19,7 @@ class TaskRepositoryTest extends BaseDatabaseTestCase
         $this->taskRepository = self::$kernel->getContainer()->get('task.storage.task');
     }
 
-    public function testFinBySystemKey()
+    public function testFindBySystemKey()
     {
         if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
             return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
@@ -34,7 +34,7 @@ class TaskRepositoryTest extends BaseDatabaseTestCase
         $this->assertEquals($task->getUuid(), $result->getUuid());
     }
 
-    public function testFinBySystemKeyNotFound()
+    public function testFindBySystemKeyNotFound()
     {
         if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
             return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
@@ -44,5 +44,23 @@ class TaskRepositoryTest extends BaseDatabaseTestCase
         $this->taskRepository->save($task);
 
         $this->assertNull($this->taskRepository->findBySystemKey('test'));
+    }
+
+    public function testFindSystemTasks()
+    {
+        if (self::$kernel->getContainer()->getParameter('kernel.storage') !== 'doctrine') {
+            return $this->markTestSkipped('This testcase will only be called for doctrine storage.');
+        }
+
+        $task1 = $this->createTask();
+        $task1->setSystemKey('test');
+        $this->taskRepository->save($task1);
+
+        $task2 = $this->createTask();
+        $this->taskRepository->save($task2);
+
+        $result = $this->taskRepository->findSystemTasks();
+        $this->assertCount(1, $result);
+        $this->assertEquals($task1->getUuid(), $result[0]->getUuid());
     }
 }

--- a/tests/Unit/Builder/TaskBuilderFactoryTest.php
+++ b/tests/Unit/Builder/TaskBuilderFactoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Unit\Builder;
+
+use Task\Scheduler\TaskSchedulerInterface;
+use Task\TaskBundle\Builder\TaskBuilder;
+use Task\TaskBundle\Builder\TaskBuilderFactory;
+use Task\TaskInterface;
+
+class TaskBuilderFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreate()
+    {
+        $task = $this->prophesize(TaskInterface::class);
+        $scheduler = $this->prophesize(TaskSchedulerInterface::class);
+
+        $taskBuilderFactory = new TaskBuilderFactory();
+
+        $this->assertInstanceOf(
+            TaskBuilder::class,
+            $taskBuilderFactory->createTaskBuilder($task->reveal(), $scheduler->reveal())
+        );
+    }
+}

--- a/tests/Unit/Builder/TaskBuilderTest.php
+++ b/tests/Unit/Builder/TaskBuilderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Task\TaskBundle\Unit\Builder;
+
+use Task\Scheduler\TaskSchedulerInterface;
+use Task\TaskBundle\Builder\NotSupportedMethodException;
+use Task\TaskBundle\Builder\TaskBuilder;
+use Task\TaskBundle\Entity\Task;
+use Task\TaskInterface;
+
+class TaskBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetSystemKey()
+    {
+        $task = $this->prophesize(Task::class);
+        $scheduler = $this->prophesize(TaskSchedulerInterface::class);
+
+        $taskBuilder = new TaskBuilder($task->reveal(), $scheduler->reveal());
+        $taskBuilder->setSystemKey('test');
+
+        $task->setSystemKey('test')->shouldBeCalled();
+    }
+
+    public function testSetSystemKeyNotSupported()
+    {
+        $this->setExpectedException(NotSupportedMethodException::class);
+
+        $task = $this->prophesize(TaskInterface::class);
+        $scheduler = $this->prophesize(TaskSchedulerInterface::class);
+
+        $taskBuilder = new TaskBuilder($task->reveal(), $scheduler->reveal());
+        $taskBuilder->setSystemKey('test');
+
+    }
+}

--- a/tests/Unit/Builder/TaskBuilderTest.php
+++ b/tests/Unit/Builder/TaskBuilderTest.php
@@ -30,6 +30,5 @@ class TaskBuilderTest extends \PHPUnit_Framework_TestCase
 
         $taskBuilder = new TaskBuilder($task->reveal(), $scheduler->reveal());
         $taskBuilder->setSystemKey('test');
-
     }
 }

--- a/tests/Unit/Command/ScheduleSystemTasksCommandTest.php
+++ b/tests/Unit/Command/ScheduleSystemTasksCommandTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Task\TaskBundle\Unit\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Task\Scheduler\TaskSchedulerInterface;
+use Task\Storage\TaskExecutionRepositoryInterface;
+use Task\TaskBundle\Builder\TaskBuilder;
+use Task\TaskBundle\Command\ScheduleSystemTasksCommand;
+use Task\TaskBundle\Entity\TaskRepository;
+use Task\TaskBundle\Tests\Functional\TestHandler;
+
+class ScheduleSystemTasksCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TaskSchedulerInterface
+     */
+    private $scheduler;
+
+    /**
+     * @var TaskRepository
+     */
+    private $taskRepository;
+
+    /**
+     * @var TaskExecutionRepositoryInterface
+     */
+    private $taskExecutionRepository;
+
+    protected function setUp()
+    {
+        $this->scheduler = $this->prophesize(TaskSchedulerInterface::class);
+        $this->taskRepository = $this->prophesize(TaskRepository::class);
+        $this->taskExecutionRepository = $this->prophesize(TaskExecutionRepositoryInterface::class);
+    }
+
+    /**
+     * @param array $systemTasks
+     *
+     * @return ScheduleSystemTasksCommand
+     */
+    protected function createCommand(array $systemTasks)
+    {
+        return new ScheduleSystemTasksCommand(
+            'task:schedule:system-tasks',
+            $systemTasks,
+            $this->scheduler->reveal(),
+            $this->taskRepository->reveal(),
+            $this->taskExecutionRepository->reveal()
+        );
+    }
+
+    public function testExecute()
+    {
+        $command = $this->createCommand(
+            [
+                'testing' => [
+                    'enabled' => true,
+                    'handler_class' => TestHandler::class,
+                    'workload' => 'test',
+                    'cron_expression' => '* * * * *',
+                ],
+            ]
+        );
+
+        $taskBuilder = $this->prophesize(TaskBuilder::class);
+
+        $this->taskRepository->findBySystemKey('testing')->willReturn(null);
+        $this->scheduler->createTask(TestHandler::class, 'test')->shouldBeCalled()->willReturn($taskBuilder->reveal());
+
+        $taskBuilder->setSystemKey('testing')->shouldBeCalled();
+        $taskBuilder->cron('* * * * *')->shouldBeCalled();
+        $taskBuilder->schedule()->shouldBeCalled();
+
+        $command->run(
+            $this->prophesize(InputInterface::class)->reveal(),
+            $this->prophesize(OutputInterface::class)->reveal()
+        );
+    }
+
+    public function testExecuteMultiple()
+    {
+        $command = $this->createCommand(
+            [
+                'testing-1' => [
+                    'enabled' => true,
+                    'handler_class' => TestHandler::class,
+                    'workload' => 'test-1',
+                    'cron_expression' => '* * * * *',
+                ],
+                'testing-2' => [
+                    'enabled' => true,
+                    'handler_class' => TestHandler::class,
+                    'workload' => 'test-2',
+                    'cron_expression' => '* * * * *',
+                ],
+            ]
+        );
+
+        $this->taskRepository->findBySystemKey('testing-1')->willReturn(null);
+        $this->taskRepository->findBySystemKey('testing-2')->willReturn(null);
+
+        $taskBuilder1 = $this->prophesize(TaskBuilder::class);
+        $this->scheduler->createTask(TestHandler::class, 'test-1')->shouldBeCalled()->willReturn($taskBuilder1->reveal());
+        $taskBuilder1->setSystemKey('testing-1')->shouldBeCalled();
+        $taskBuilder1->cron('* * * * *')->shouldBeCalled();
+        $taskBuilder1->schedule()->shouldBeCalled();
+
+        $taskBuilder2 = $this->prophesize(TaskBuilder::class);
+        $this->scheduler->createTask(TestHandler::class, 'test-2')->shouldBeCalled()->willReturn($taskBuilder2->reveal());
+        $taskBuilder2->setSystemKey('testing-2')->shouldBeCalled();
+        $taskBuilder2->cron('* * * * *')->shouldBeCalled();
+        $taskBuilder2->schedule()->shouldBeCalled();
+
+        $command->run(
+            $this->prophesize(InputInterface::class)->reveal(),
+            $this->prophesize(OutputInterface::class)->reveal()
+        );
+    }
+
+    // TODO Tests for update and disable.
+}

--- a/tests/Unit/DependencyInjection/HandlerCompilerPassTest.php
+++ b/tests/Unit/DependencyInjection/HandlerCompilerPassTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Unit\DependencyInjection;
+namespace Task\TaskBundle\Unit\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;

--- a/tests/app/config/config.doctrine.yml
+++ b/tests/app/config/config.doctrine.yml
@@ -1,5 +1,11 @@
 task:
     storage: doctrine
+    system_tasks:
+        testing:
+            enabled: true
+            handler_class: Task\TaskBundle\Tests\Functional\TestHandler
+            workload: ['test']
+            cron_expression: '* * * * *'
 
 doctrine:
     orm:


### PR DESCRIPTION
This PR introduces the feature of system tasks. You can now configure predefined tasks in you config tree:

```yml
task:
    system_tasks:
        my_task:
            enabled: true
            handler_class: 'AppBundle\Handler\TestHandler'
            workload: 'my workload'
            interval: '@daily'
        ...
```

Related PR: https://github.com/php-task/php-task/pull/31 https://github.com/php-task/docs/pull/4

### TODO

- [x] docs