### PR TITLE
Fixed environment argument

### DIFF
--- a/src/Executor/ExecutionProcessFactory.php
+++ b/src/Executor/ExecutionProcessFactory.php
@@ -40,7 +40,7 @@ class ExecutionProcessFactory
     public function create($uuid)
     {
         return $process = ProcessBuilder::create(
-            [$this->consolePath, 'task:execute', $uuid, '-e ' . $this->environment]
+            [$this->consolePath, 'task:execute', $uuid, '--env=' . $this->environment]
         )->getProcess();
     }
 }


### PR DESCRIPTION
The symfony process escapes the space in a way that the called symfony console cannot detect it as an option.