### PR TITLE
Fix branch alias for 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "minimum-stability": "dev",
     "extra": {
-        "branch-aliases": {
+        "branch-alias": {
             "dev-develop": "2.0-dev"
         }
     }


### PR DESCRIPTION
currently the branch alias does not work because of a typo error.