### PR TITLE
Allowing doctrine3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/process": "^5.4 || ^6.0 || ^7.0",
-        "doctrine/orm": "^2.5.3"
+        "doctrine/orm": "^2.5.3 || ^3.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",

--- a/src/Command/ScheduleSystemTasksCommand.php
+++ b/src/Command/ScheduleSystemTasksCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Task\Scheduler\TaskSchedulerInterface;
 use Task\Storage\TaskExecutionRepositoryInterface;
 use Task\TaskBundle\Builder\TaskBuilder;
+use Task\TaskBundle\Entity\SystemTaskRepositoryInterface;
 use Task\TaskBundle\Entity\TaskRepository;
 use Task\TaskInterface;
 use Task\TaskStatus;
@@ -29,7 +30,7 @@ class ScheduleSystemTasksCommand extends Command
     private $scheduler;
 
     /**
-     * @var TaskRepository
+     * @var SystemTaskRepositoryInterface
      */
     private $taskRepository;
 
@@ -42,14 +43,14 @@ class ScheduleSystemTasksCommand extends Command
      * @param string $name
      * @param array $systemTasks
      * @param TaskSchedulerInterface $scheduler
-     * @param TaskRepository $taskRepository
+     * @param SystemTaskRepositoryInterface $taskRepository
      * @param TaskExecutionRepositoryInterface $taskExecutionRepository
      */
     public function __construct(
         $name,
         array $systemTasks,
         TaskSchedulerInterface $scheduler,
-        TaskRepository $taskRepository,
+        SystemTaskRepositoryInterface $taskRepository,
         TaskExecutionRepositoryInterface $taskExecutionRepository
     ) {
         parent::__construct($name);

--- a/src/Entity/SystemTaskRepositoryInterface.php
+++ b/src/Entity/SystemTaskRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Task\TaskBundle\Entity;
+
+use Task\Storage\TaskRepositoryInterface;
+
+interface SystemTaskRepositoryInterface extends TaskRepositoryInterface
+{
+    /**
+     * Returns all system-task.
+     *
+     * @return TaskInterface[]
+     */
+    public function findSystemTasks();
+
+    /**
+     * Returns task identified by system-key.
+     *
+     * @param string $systemKey
+     *
+     * @return TaskInterface
+     */
+    public function findBySystemKey($systemKey);
+}

--- a/src/Entity/TaskRepository.php
+++ b/src/Entity/TaskRepository.php
@@ -11,15 +11,17 @@
 
 namespace Task\TaskBundle\Entity;
 
+use DateTime;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
-use Task\Storage\TaskRepositoryInterface;
 use Task\TaskInterface;
 
 /**
- * Repository for task.
+ * Repository for tasks
+ *
+ * @extends EntityRepository<TaskInterface>
  */
-class TaskRepository extends EntityRepository implements TaskRepositoryInterface
+class TaskRepository extends EntityRepository implements SystemTaskRepositoryInterface
 {
     /**
      * {@inheritdoc}
@@ -62,7 +64,7 @@ class TaskRepository extends EntityRepository implements TaskRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function findAll($page = 1, $pageSize = null)
+    public function findAll($page = 1, $pageSize = null): array
     {
         $query = $this->createQueryBuilder('t')
             ->getQuery();
@@ -100,11 +102,7 @@ class TaskRepository extends EntityRepository implements TaskRepositoryInterface
     }
 
     /**
-     * Returns task identified by system-key.
-     *
-     * @param string $systemKey
-     *
-     * @return TaskInterface
+     * {@inheritdoc}
      */
     public function findBySystemKey($systemKey)
     {
@@ -120,9 +118,7 @@ class TaskRepository extends EntityRepository implements TaskRepositoryInterface
     }
 
     /**
-     * Returns all system-task.
-     *
-     * @return TaskInterface[]
+     * {@inheritdoc}
      */
     public function findSystemTasks()
     {

--- a/tests/Unit/Command/ScheduleSystemTasksCommandTest.php
+++ b/tests/Unit/Command/ScheduleSystemTasksCommandTest.php
@@ -13,8 +13,8 @@ use Task\Scheduler\TaskSchedulerInterface;
 use Task\Storage\TaskExecutionRepositoryInterface;
 use Task\TaskBundle\Builder\TaskBuilder;
 use Task\TaskBundle\Command\ScheduleSystemTasksCommand;
+use Task\TaskBundle\Entity\SystemTaskRepositoryInterface;
 use Task\TaskBundle\Entity\Task;
-use Task\TaskBundle\Entity\TaskRepository;
 use Task\TaskBundle\Tests\Functional\TestHandler;
 use Task\TaskStatus;
 
@@ -28,7 +28,7 @@ class ScheduleSystemTasksCommandTest extends TestCase
     private $scheduler;
 
     /**
-     * @var TaskRepository
+     * @var SystemTaskRepositoryInterface
      */
     private $taskRepository;
 
@@ -40,7 +40,7 @@ class ScheduleSystemTasksCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->scheduler = $this->prophesize(TaskSchedulerInterface::class);
-        $this->taskRepository = $this->prophesize(TaskRepository::class);
+        $this->taskRepository = $this->prophesize(SystemTaskRepositoryInterface::class);
         $this->taskExecutionRepository = $this->prophesize(TaskExecutionRepositoryInterface::class);
     }
 


### PR DESCRIPTION
In the new version of doctrine 3 the `EntityRepository` has a property which uses an intersection type this confused the prophecy. This is why I needed to add a new interface to the application.